### PR TITLE
キャッシュの共有範囲の表現を変更

### DIFF
--- a/ja.md
+++ b/ja.md
@@ -181,7 +181,7 @@ self.addEventListener('activate', function(event) {
           // > but remember that caches are shared across
           // > the whole origin
           // キャッシュから削除したい場合trueを返します。
-          // キャッシュはすべてのオリジンで共有されている
+          // キャッシュはオリジン全体で共有されている
           // ことに注意してください。
         }).map(function(cacheName) {
           return caches.delete(cacheName);


### PR DESCRIPTION
@kuu 
初めまして。
素晴らしい翻訳をありがとうございます！
とてもこなれた翻訳で、読みやすかったです。

一か所、読んでいて誤解してしまった所があったので、修正版をプルリクエストします。
「すべてのオリジンで共有」と言われると、example.comとexample.orgのドメイン違いの所でも同じキャッシュを使っているように感じてしまいました。
実際には、今見ているコードに関係ない部分でも、同じオリジンならキャッシュとその名前を共有するので注意されたい、ということだと思います。
（「オリジン全体で」と言い直すことでそれが伝わるかは、少々不安ですが……）

いかがでしょうか、ご検討お願いします。
